### PR TITLE
Add tests for rest params in handler

### DIFF
--- a/fixtures/rest-params.ts
+++ b/fixtures/rest-params.ts
@@ -1,3 +1,3 @@
 export default (foo: string, ...params: any[]) => {
-  return JSON.stringify({ foo, ...params })
+  return JSON.stringify({ foo, params })
 }

--- a/packages/fts-http/src/handler.test.ts
+++ b/packages/fts-http/src/handler.test.ts
@@ -51,6 +51,7 @@ for (const fixture of fixtures) {
     t.truthy(definition)
 
     const isHttpResponse = !!definition.returns.http
+    const supportsRest = definition.params.schema.additionalProperties
     const validator = createValidator()
     const paramsDecoder = validator.decoder(definition.params.schema)
     const returnsEncoder = validator.encoder(definition.returns.schema)
@@ -73,6 +74,12 @@ for (const fixture of fixtures) {
       (key) => paramsLocal[key]
     )
     const func = HTTP.requireHandlerFunction(definition, jsFilePath)
+
+    if (supportsRest) {
+      const additionalProperty = 'Hello, World!'
+      params.additionalProperty = additionalProperty
+      paramsLocalArray.push(['additionalProperty', additionalProperty])
+    }
 
     const result = await Promise.resolve(func(...paramsLocalArray))
     const expected = { result }


### PR DESCRIPTION
Adds missing tests from #14

Doesn't add support for POSTArray, since this seemed to be dropping additional params after the first param. I could have been missing something. As discussed offline, it seems we're going to be deprecating support.